### PR TITLE
feat(cli): move --verbose and --debug to global options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,8 @@ It reads from CLI and environment the configuration and run the Pipeline on an o
 
 - Run on a given user/group
   ```sh
-  ./src-fingerprint --provider github --object Uber
-  ./src-fingerprint --provider-url http://gitlab.example.com --provider gitlab --object Groupe
+  ./src-fingerprint collect --provider github --object Uber
+  ./src-fingerprint collect --provider-url http://gitlab.example.com --provider gitlab --object Groupe
   ```
 
 ## Performance considerations

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ Note that by default, `src-fingerprint` will exclude forked repositories from th
 1. Export all fingerprints from private repositories from a GitHub Org to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider github --object ORG_NAME
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --object ORG_NAME
 ```
 
 2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz`:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider github --include-public-repos --include-forked-repos --include-archived-repos
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider github --include-public-repos --include-forked-repos --include-archived-repos
 ```
 
 ### GitLab
@@ -141,13 +141,13 @@ env VCS_TOKEN="<token>" src-fingerprint -v --provider github --include-public-re
 1. Export all fingerprints from private repositories of a GitLab group to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --object "GitGuardian-dev-group"
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --object "GitGuardian-dev-group"
 ```
 
 2. Export all fingerprints of every project the user can access to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --include-forked-repos
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider gitlab --include-forked-repos
 ```
 
 ### Bitbucket server (formely Atlassian Stash)
@@ -155,13 +155,13 @@ env VCS_TOKEN="<token>" src-fingerprint -v --provider gitlab --include-forked-re
 1. Export all fingerprints from a Bitbucket project with private repository to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider bitbucket --object "GitGuardian Project"
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider bitbucket --object "GitGuardian Project"
 ```
 
 2. Export all fingerprints of every repository the user can access to the default path `./fingerprints.jsonl.gz` with logs:
 
 ```sh
-env VCS_TOKEN="<token>" src-fingerprint -v --provider bitbucket
+env VCS_TOKEN="<token>" src-fingerprint -v collect --provider bitbucket
 ```
 
 ### Repository

--- a/cmd/src-fingerprint/main.go
+++ b/cmd/src-fingerprint/main.go
@@ -91,6 +91,20 @@ func main() {
 		Name:    "src-fingerprint",
 		Version: version,
 		Usage:   "src-fingerprint is a tool to collect and manipulate source code fingerprints.",
+		Before:  beforeAction,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Value:   false,
+				Usage:   "Run with verbose logging",
+			},
+			&cli.BoolFlag{
+				Name:  "debug",
+				Value: false,
+				Usage: "debug logging, override verbose",
+			},
+		},
 		Commands: []*cli.Command{
 			{
 				Name:   "collect",
@@ -111,22 +125,6 @@ func main() {
 						Name:    "object",
 						Aliases: []string{"u"},
 						Usage:   "repository|org|group to scrape. If not specified all reachable repositories will be collected.",
-					},
-					&cli.BoolFlag{
-						Name:    "verbose",
-						Aliases: []string{"v"},
-						Value:   false,
-						Usage:   "Run with verbose logging",
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Value: false,
-						Usage: "debug logging, override verbose",
-					},
-					&cli.BoolFlag{
-						Name:  "debug",
-						Value: false,
-						Usage: "Run with debug logging, overrides verbose",
 					},
 					&cli.BoolFlag{
 						Name:  "include-forked-repos",
@@ -200,7 +198,7 @@ func main() {
 	}
 }
 
-func collectAction(c *cli.Context) error {
+func beforeAction(c *cli.Context) error {
 	if c.Bool("debug") {
 		log.SetLevel(log.DebugLevel)
 	} else if c.Bool("verbose") {
@@ -209,6 +207,10 @@ func collectAction(c *cli.Context) error {
 		log.SetLevel(log.WarnLevel)
 	}
 
+	return nil
+}
+
+func collectAction(c *cli.Context) error {
 	output := os.Stdout
 	fsOutput := false
 


### PR DESCRIPTION
The changes I propose would be unreadable if I tried to use the code suggestion feature on your PR, so I made my own PR into your branch.

`--verbose` and `--debug` are not specific to the command `collect`, I propose to make them global options.